### PR TITLE
refactor:変数の再宣言を解消する

### DIFF
--- a/src/commands/omikuji.js
+++ b/src/commands/omikuji.js
@@ -8,16 +8,16 @@ exports.run = async (client, message, args) => {
     try{
         function ko(){
             const arr = ["や！","こばわ"];
-            let random = Math.floor(Math.random() * arr.length);
-            let result_ko = arr[random];
+            const random = Math.floor(Math.random() * arr.length);
+            const result_ko = arr[random];
             message.channel.send({content: result_ko});
             return result_ko;
         }
 
         function namagomi(){
             const arr = ["生ゴミ", "黙れゴミ"];
-            let random = Math.floor(Math.random() * arr.length);
-            let result_namagomi = arr[random];
+            const random = Math.floor(Math.random() * arr.length);
+            const result_namagomi = arr[random];
             message.channel.send({content: result_namagomi});
             return result_namagomi;
         }

--- a/src/commands/omikuji.js
+++ b/src/commands/omikuji.js
@@ -1,4 +1,5 @@
 const logger = require('../modules/logger')
+const config = require('../utils/get-config');
 const err_embed = require('../utils/error-embed');
 const OmikujiModel = require('../utils/Schema/OmikujiSchema')
 const profileModel = require('../utils/Schema/ProfileSchema');
@@ -6,103 +7,106 @@ const { MessageEmbed } = require('discord.js');
 exports.run = async (client, message, args) => {
     try{
         function ko(){
-        let arr = ["や！","こばわ"];
-        var random = Math.floor(Math.random() * arr.length);
-        var result = arr[random];
-        message.channel.send({content: result});
-        return result;
+            const arr = ["や！","こばわ"];
+            let random = Math.floor(Math.random() * arr.length);
+            let result_ko = arr[random];
+            message.channel.send({content: result_ko});
+            return result_ko;
         }
 
         function namagomi(){
-        let arr = ["生ゴミ", "黙れゴミ"];
-        var random = Math.floor(Math.random() * arr.length);
-        var result = arr[random];
-        message.channel.send({content: result});
-        return result;
+            const arr = ["生ゴミ", "黙れゴミ"];
+            let random = Math.floor(Math.random() * arr.length);
+            let result_namagomi = arr[random];
+            message.channel.send({content: result_namagomi});
+            return result_namagomi;
         }
         
-            const OmikujiData = await OmikujiModel.findOne({ _id: message.author.id });
-            const profileData = await profileModel.findOne({ _id: message.author.id });
-            if (!OmikujiData) {
-                logger.error("ユーザー名: " + message.author.username + " ユーザーID: " + message.author.id + "のおみくじプロファイルが見つかりませんでした...")
-                message.channel.send(({embeds: [err_embed.main]}))
-                return;
-            }
-            if (!profileData) {
-                logger.error("ユーザー名: " + message.author.username + " ユーザーID: " + message.author.id + "のプロファイルが見つかりませんでした...")
-                message.channel.send(({embeds: [err_embed.main]}))
-                return;
-            }
-            if(OmikujiData.one_day_omikuji_feature.includes("true")){
-                if(OmikujiData.one_day_omikuji.includes("true")){
-                    var sudeni_1day_true = new MessageEmbed({
-                        title: "おみくじ",
-                        description: "すでに今日はおみくじを実行しています",
-                        color: 5301186,
-                        "footer": {
-                            "text": "ぶひ"
-                        },
-                        fields: [
-                            {
-                                name: "この機能を無効化するには",
-                                value: "`" + profileData.prefix + "one-day-kuji` コマンドを実行してください"
-                            },
-                        ]
-                    })
-                    message.channel.send({embeds: [sudeni_1day_true]})
-                    return;
-                }
-            }
-            //ごみ
-            if(message.author.id.includes("538308521985572867")){
-                var random = Math.floor(Math.random() * 2);
-                if(random == 1){
-                    var unique = "true"
-                    var result = namagomi()
-                }
-            }
-            //ko
-            if(message.author.id.includes("666277504260112429")){
-                var random = Math.floor(Math.random() * 2);
-                if(random == 1){
-                    var unique = "true"
-                    var result = ko()
-                }    
-            }
-            if (unique != "true"){
-                let arr = ["ちょうだいきち", "大吉", "吉", "中吉", "小吉", "半吉", "ぶひ吉", "凶", "大凶", "ちょうだいきょう", "ﾌﾞｯｸﾌﾞｯｸ", "ﾌｸﾞｩ🐡"];
-                var random = Math.floor(Math.random() * arr.length);
-                var result = arr[random];
-            
-                var maeno_data = OmikujiData.mae_no_omikuji_kekka
-                var success = new MessageEmbed({
+        const OmikujiData = await OmikujiModel.findOne({ _id: message.author.id });
+        const profileData = await profileModel.findOne({ _id: message.author.id });
+        if (!OmikujiData) {
+            logger.error("ユーザー名: " + message.author.username + " ユーザーID: " + message.author.id + "のおみくじプロファイルが見つかりませんでした...")
+            message.channel.send(({embeds: [err_embed.main]}))
+            return;
+        }
+        if (!profileData) {
+            logger.error("ユーザー名: " + message.author.username + " ユーザーID: " + message.author.id + "のプロファイルが見つかりませんでした...")
+            message.channel.send(({embeds: [err_embed.main]}))
+            return;
+        }
+        if(OmikujiData.one_day_omikuji_feature.includes("true")){
+            if(OmikujiData.one_day_omikuji.includes("true")){
+                let sudeni_1day_true = new MessageEmbed({
                     title: "おみくじ",
-                    description: "おみくじをしたよ～",
+                    description: "すでに今日はおみくじを実行しています",
                     color: 5301186,
                     "footer": {
                         "text": "ぶひ"
                     },
                     fields: [
                         {
-                            name: "結果: ",
-                            value: result
-                        },
-                        {
-                            name: "前回の結果: ",
-                            value: maeno_data
+                            name: "この機能を無効化するには",
+                            value: "`" + profileData.prefix + "one-day-kuji` コマンドを実行してください"
                         },
                     ]
                 })
-            message.channel.send({embeds: [success]})
+                message.channel.send({embeds: [sudeni_1day_true]})
+                return;
             }
-            if(OmikujiData.one_day_omikuji_feature.includes("true")){
-                await OmikujiData.updateOne({
-                    one_day_omikuji: true,
-                })
+        }
+
+        let result;
+        let unique;
+        //ごみ
+        if(message.author.id.includes("538308521985572867")){
+            let random = Math.floor(Math.random() * 2);
+            if(random == 1){
+                unique = "true"
+                result = namagomi()
             }
-            await OmikujiData.updateOne({
-                mae_no_omikuji_kekka: result,
+        }
+        //ko
+        if(message.author.id.includes("666277504260112429")){
+            let random = Math.floor(Math.random() * 2);
+            if(random == 1){
+                unique = "true"
+                result = ko()
+            }    
+        }
+        if (unique != "true"){
+            const arr = ["ちょうだいきち", "大吉", "吉", "中吉", "小吉", "半吉", "ぶひ吉", "凶", "大凶", "ちょうだいきょう", "ﾌﾞｯｸﾌﾞｯｸ", "ﾌｸﾞｩ🐡"];
+            let random = Math.floor(Math.random() * arr.length);
+            result = arr[random];
+        
+            let maeno_data = OmikujiData.mae_no_omikuji_kekka
+            let success = new MessageEmbed({
+                title: "おみくじ",
+                description: "おみくじをしたよ～",
+                color: 5301186,
+                "footer": {
+                    "text": "ぶひ"
+                },
+                fields: [
+                    {
+                        name: "結果: ",
+                        value: result
+                    },
+                    {
+                        name: "前回の結果: ",
+                        value: maeno_data
+                    },
+                ]
             })
+            message.channel.send({embeds: [success]})
+        }
+        if(OmikujiData.one_day_omikuji_feature.includes("true")){
+            await OmikujiData.updateOne({
+                one_day_omikuji: true,
+            })
+        }
+        await OmikujiData.updateOne({
+            mae_no_omikuji_kekka: result,
+        })
         } catch (err) {
             logger.error("コマンド実行エラーが発生しました")
             logger.error(err)
@@ -112,7 +116,7 @@ exports.run = async (client, message, args) => {
                 message.channel.send("エラー内容: ")
                 message.channel.send("```\n"+ err + "\n```")
             }
-    }
+        }
 }
 
 exports.name = "omikuji";

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -1,7 +1,7 @@
 const config = require('../utils/get-config');
 const { MessageEmbed } = require('discord.js');
 const logger = require('../modules/logger')
-const msg_replay = require('../sub-systems/message-reply')
+const msg_reply = require('../sub-systems/message-reply')
 const url = require('../sub-systems/url-show')
 
 // DBSchema
@@ -19,14 +19,15 @@ module.exports = async (client, message) => {
     url.discord_ptb_com(client, message)
 
     // とあるメッセージに対して画像を送ったりする
-    msg_replay(message)
+    msg_reply(message)
 
     // profileデータがある場合はDBから ない場合はconfigからprefixを取得する
     const profileData = await profileModel.findOne({ _id: message.author.id });
+    let prefix;
     if (!profileData) {
-      var prefix =  config.bot.prefix
+      prefix =  config.bot.prefix
     } else {
-      var prefix = profileData.prefix
+      prefix = profileData.prefix
     }
 
     // ここから先prefixを持ってない人以外無視する

--- a/src/sub-systems/kagawa-notification.js
+++ b/src/sub-systems/kagawa-notification.js
@@ -5,9 +5,10 @@ module.exports = (client, message) => {
 
 const today = new Date();
 const dayOfweek = today.getDay()
+let embed;
 
 if ( dayOfweek == 0 || dayOfweek == 6 ) {
-    var embed =  new MessageEmbed({
+    embed =  new MessageEmbed({
         title: "香川チャレンジの時間です",
         color: 5301186,
         description: "Minecraft-v1.16.5を起動しましょう",
@@ -19,7 +20,7 @@ if ( dayOfweek == 0 || dayOfweek == 6 ) {
         ]
     })
 } else {
-    var embed =  new MessageEmbed({
+    embed =  new MessageEmbed({
         title: "香川チャレンジの時間です",
         color: 5301186,
         description: "Minecraft-v1.16.5を起動しましょう",


### PR DESCRIPTION
#27 
変数の再宣言をつぶすことで意図しない不具合の発生を回避する目的がある(と解釈した)
- var宣言による影響で再宣言していた箇所をlet宣言にする
→再宣言を受け付けないようにする

👀 その他
再宣言を不可能にする
- let/const宣言にできそうなところはvar宣言から変更している
typo
- src/events/messageCreate.jsの`msg_replay`
→`msg_reply`のtypoのような気がする