### PR TITLE
fix:statusコマンドのMemory情報を修正

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -45,8 +45,13 @@ exports.run = (client, message, args) => {
           value: mempercent + "%",
         },
         {
-          name: "bot-version",
+          name: "Bot Version",
           value: package.version,
+          inline: true,
+        },
+        {
+          name: "Node.js Version",
+          value: process.version,
           inline: true,
         },
         {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -17,14 +17,19 @@ exports.run = (client, message, args) => {
     const totalmem_gb = totalmem_mb / 1024;
     // メモリ使用率を計算
     const mem_gb_per = (freemem_gb / totalmem_gb) * 100;
+    // プロセス全体の使用メモリを計算
+    const heapmem_byte = process.memoryUsage().rss;
+    const heapmem_mb = heapmem_byte / Math.pow(1024, 2);
 
     function floorDecimal(val, digit) {
       return Math.floor(val * Math.pow(10, digit)) / Math.pow(10, digit);
     }
+
     // 小数桁の切り下げ
-    const freemem = floorDecimal(freemem_gb, 3);
-    const totalmem = floorDecimal(totalmem_gb, 3);
+    const freemem = floorDecimal(freemem_gb, 2);
+    const totalmem = floorDecimal(totalmem_gb, 2);
     const mempercent = floorDecimal(mem_gb_per, 2);
+    const heapmem = floorDecimal(heapmem_mb, 2);
     var embed = new MessageEmbed({
       title: "SystemStatus",
       color: 5301186,
@@ -43,6 +48,10 @@ exports.run = (client, message, args) => {
         {
           name: "OS Memory Usage Per",
           value: mempercent + "%",
+        },
+        {
+          name: "Process Total Memory",
+          value: heapmem + "MB",
         },
         {
           name: "Bot Version",

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -10,8 +10,17 @@ exports.run = (client, message, args) => {
     const freemem_kb = freemem_byte / 1024;
     const freemem_mb = freemem_kb / 1024;
     const freemem_gb = freemem_mb / 1024;
-    const freemem = Math.floor(freemem_gb * 1000) / 1000;
-
+    const totalmem_byte = os.totalmem;
+    const totalmem_kb = totalmem_byte / 1024;
+    const totalmem_mb = totalmem_kb / 1024;
+    const totalmem_gb = totalmem_mb / 1024;
+    const mem_gb_per = (freemem_gb / totalmem_gb) * 100;
+    function floorDecimal(val, digit) {
+      return Math.floor(val * Math.pow(10, digit)) / Math.pow(10, digit);
+    }
+    const freemem = floorDecimal(freemem_gb, 3);
+    const totalmem = floorDecimal(totalmem_gb, 3);
+    const mempercent = floorDecimal(mem_gb_per, 2);
     var embed = new MessageEmbed({
       title: "SystemStatus",
       color: 5301186,
@@ -24,8 +33,12 @@ exports.run = (client, message, args) => {
           value: os.type() + "," + os.version() + " " + os.arch(),
         },
         {
-          name: "OS Free Memory",
-          value: freemem + " GB",
+          name: "OS Free Memory / Total Memory",
+          value: freemem + " / " + totalmem + "GB",
+        },
+        {
+          name: "OS Memory Usage Per",
+          value: mempercent + "%",
         },
         {
           name: "bot-version",

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,54 +1,55 @@
-const { MessageEmbed } = require('discord.js');
-const package = require('../../package.json');
-const os = require('os')
-const logger = require('../modules/logger')
-const err_embed = require('../utils/error-embed')
+const { MessageEmbed } = require("discord.js");
+const package = require("../../package.json");
+const os = require("os");
+const logger = require("../modules/logger");
+const err_embed = require("../utils/error-embed");
 
 exports.run = (client, message, args) => {
-
-    try{
+  try {
     // 空きメモリを計算
-    const freemem_byte = os.freemem
-    const freemem_kb = freemem_byte /1024
-    const freemem = freemem_kb /1024
+    const freemem_byte = os.freemem;
+    const freemem_kb = freemem_byte / 1024;
+    const freemem_mb = freemem_kb / 1024;
+    const freemem_gb = freemem_mb / 1024;
+
     var embed = new MessageEmbed({
-        title: "SystemStatus",
-        color: 5301186,
-        "footer": {
-            "text": "System Status"
+      title: "SystemStatus",
+      color: 5301186,
+      footer: {
+        text: "System Status",
+      },
+      fields: [
+        {
+          name: "Os Information",
+          value: os.type() + "," + os.version() + " " + os.arch(),
         },
-        fields: [
-            {
-                name: "Os Information",
-                value: os.type() + "," + os.version() + " " + os.arch()
-            },
-            {
-                name: "Free Memory",
-                value: freemem + " MB"
-            },
-            {
-                "name": "bot-version",
-                "value": package.version,
-                "inline": true
-              },
-              {
-                "name": "Discord.js Version",
-                "value": require('discord.js').version,
-                "inline": true
-              }
-        ]
-    })
-    message.channel.send({embeds: [embed]})
-    } catch (err) {
-            logger.error("コマンド実行エラーが発生しました")
-            logger.error(err)
-            message.channel.send(({embeds: [err_embed.main]}))
-            if(config.debug.enable.includes("true")){
-                message.channel.send(({embeds: [err_embed.debug]}))
-                message.channel.send("エラー内容: ")
-                message.channel.send("```\n"+ err + "\n```")
-            }
+        {
+          name: "Free Memory",
+          value: freemem_gb + " GB",
+        },
+        {
+          name: "bot-version",
+          value: package.version,
+          inline: true,
+        },
+        {
+          name: "Discord.js Version",
+          value: require("discord.js").version,
+          inline: true,
+        },
+      ],
+    });
+    message.channel.send({ embeds: [embed] });
+  } catch (err) {
+    logger.error("コマンド実行エラーが発生しました");
+    logger.error(err);
+    message.channel.send({ embeds: [err_embed.main] });
+    if (config.debug.enable.includes("true")) {
+      message.channel.send({ embeds: [err_embed.debug] });
+      message.channel.send("エラー内容: ");
+      message.channel.send("```\n" + err + "\n```");
     }
-}
+  }
+};
 
 exports.name = "status";

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,7 +3,6 @@ const package = require("../../package.json");
 const os = require("os");
 const logger = require("../modules/logger");
 const err_embed = require("../utils/error-embed");
-const mem_
 exports.run = (client, message, args) => {
   try {
     // 空きメモリを計算
@@ -21,11 +20,11 @@ exports.run = (client, message, args) => {
       },
       fields: [
         {
-          name: "Os Information",
+          name: "OS Information",
           value: os.type() + "," + os.version() + " " + os.arch(),
         },
         {
-          name: "Free Memory",
+          name: "OS Free Memory",
           value: freemem + " GB",
         },
         {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,7 +3,7 @@ const package = require("../../package.json");
 const os = require("os");
 const logger = require("../modules/logger");
 const err_embed = require("../utils/error-embed");
-
+const mem_
 exports.run = (client, message, args) => {
   try {
     // 空きメモリを計算
@@ -11,6 +11,7 @@ exports.run = (client, message, args) => {
     const freemem_kb = freemem_byte / 1024;
     const freemem_mb = freemem_kb / 1024;
     const freemem_gb = freemem_mb / 1024;
+    const freemem = Math.floor(freemem_gb * 1000) / 1000;
 
     var embed = new MessageEmbed({
       title: "SystemStatus",
@@ -25,7 +26,7 @@ exports.run = (client, message, args) => {
         },
         {
           name: "Free Memory",
-          value: freemem_gb + " GB",
+          value: freemem + " GB",
         },
         {
           name: "bot-version",

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -10,14 +10,18 @@ exports.run = (client, message, args) => {
     const freemem_kb = freemem_byte / 1024;
     const freemem_mb = freemem_kb / 1024;
     const freemem_gb = freemem_mb / 1024;
+    // 合計メモリを計算
     const totalmem_byte = os.totalmem;
     const totalmem_kb = totalmem_byte / 1024;
     const totalmem_mb = totalmem_kb / 1024;
     const totalmem_gb = totalmem_mb / 1024;
+    // メモリ使用率を計算
     const mem_gb_per = (freemem_gb / totalmem_gb) * 100;
+
     function floorDecimal(val, digit) {
       return Math.floor(val * Math.pow(10, digit)) / Math.pow(10, digit);
     }
+    // 小数桁の切り下げ
     const freemem = floorDecimal(freemem_gb, 3);
     const totalmem = floorDecimal(totalmem_gb, 3);
     const mempercent = floorDecimal(mem_gb_per, 2);


### PR DESCRIPTION
メモリ情報の埋め込みメッセージを修正する
- 小数桁の切り捨て
→今のやつは桁数多すぎるので…
- OSの合計メモリの表示など
→{空きメモリ/合計メモリ}みたいな感じにする