### PR TITLE
fix:`block`と`hardblock`の重複実行・実行通知をしないよう修正

### DIFF
--- a/src/commands/block.js
+++ b/src/commands/block.js
@@ -7,113 +7,108 @@ const BlockUserModel = require("../utils/Schema/BlockUserSchema");
 const err_embed = require("../utils/error-embed");
 
 exports.run = async (client, message, args) => {
-  try {
-    // 権限の確認
-    const permission_check = check_admin(message, client);
+    try {
+        // 権限の確認
+        const permission_check = check_admin(message, client);
 
-    if (permission_check == "owner: no") {
-      return;
+        if (permission_check == "owner: no") {
+            return;
+        }
+
+        const args = message.content.split(" ").slice(1);
+        const input = args.join(" ");
+
+        // ユーザーIDが指定されていない場合
+        const err_argument = new MessageEmbed({
+            title: "ユーザーブロック",
+            description: "コマンド実行エラー: 引数が指定されていません",
+            color: 16601703,
+            fields: [
+                {
+                    name: "コマンド実行に必要な引数",
+                    value: "`block 【ブロックするユーザーID】`",
+                },
+                {
+                    name: "実行例: ",
+                    value: "`block 927919368665456710`",
+                },
+            ],
+        });
+
+        if (!input) {
+            message.channel.send({ embeds: [err_argument] });
+            return;
+        }
+
+        const profileData = await profileModel.findOne({ _id: input });
+
+        if (!profileData) {
+            message.channel.send("エラー: ユーザープロファイルが見つかりませんでした");
+            logger.error(
+                "ユーザーID: " +
+                    input +
+                    " のプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
+            );
+            return;
+        }
+
+        // block profileの確認
+        const BlockData = await BlockUserModel.findOne({ _id: input });
+        if (!BlockData) {
+            message.channel.send("エラー: ユーザーブロックプロファイルが見つかりませんでした");
+            logger.error(
+                "ユーザーID: " +
+                    input +
+                    " のブロックプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
+            );
+            return;
+        }
+
+        if (config.bot.owner.includes(input)) {
+            message.channel.send("さすがにbotのownerをブロックすることはできません");
+            return;
+        }
+
+        await BlockData.updateOne({
+            enable: true,
+        });
+
+        const data = new MessageEmbed({
+            title: "ユーザーブロック",
+            description: "ユーザーをブロックしました",
+            color: 3853014,
+            timestamp: new Date(),
+            thumbnail: {
+                url: profileData.avatar,
+            },
+            fields: [
+                {
+                    name: "ユーザーID: ",
+                    value: "`" + input + "`",
+                    inline: true,
+                },
+                {
+                    name: "ユーザー名: ",
+                    value: "`" + profileData.name + "`",
+                    inline: true,
+                },
+                {
+                    name: "Note: ",
+                    value: "ブロックを解除する場合は `unblock` コマンドを \n ハードブロックする場合は `hardblock` コマンドを実行してください",
+                },
+            ],
+        });
+        message.channel.send({ embeds: [data] });
+    } catch (err) {
+        logger.error("コマンド実行エラーが発生しました");
+        logger.error(err);
+        message.channel.send({ embeds: [err_embed.main] });
+        if (config.debug.enable.includes("true")) {
+            message.channel.send({ embeds: [err_embed.debug] });
+            message.channel.send("エラー内容: ");
+            message.channel.send("```\n" + err + "\n```");
+        }
     }
-
-    const args = message.content.split(" ").slice(1);
-    const input = args.join(" ");
-
-    // ユーザーIDが指定されていない場合
-    const err_argument = new MessageEmbed({
-      title: "ユーザーブロック",
-      description: "コマンド実行エラー: 引数が指定されていません",
-      color: 16601703,
-      fields: [
-        {
-          name: "コマンド実行に必要な引数",
-          value: "`block 【ブロックするユーザーID】`",
-        },
-        {
-          name: "実行例: ",
-          value: "`block 927919368665456710`",
-        },
-      ],
-    });
-
-    if (!input) {
-      message.channel.send({ embeds: [err_argument] });
-      return;
-    }
-
-    const profileData = await profileModel.findOne({ _id: input });
-
-    if (!profileData) {
-      message.channel.send(
-        "エラー: ユーザープロファイルが見つかりませんでした"
-      );
-      logger.error(
-        "ユーザーID: " +
-          input +
-          " のプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
-      );
-      return;
-    }
-
-    // block profileの確認
-    const BlockData = await BlockUserModel.findOne({ _id: input });
-    if (!BlockData) {
-      message.channel.send(
-        "エラー: ユーザーブロックプロファイルが見つかりませんでした"
-      );
-      logger.error(
-        "ユーザーID: " +
-          input +
-          " のブロックプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
-      );
-      return;
-    }
-
-    if (config.bot.owner.includes(input)) {
-      message.channel.send("さすがにbotのownerをブロックすることはできません");
-      return;
-    }
-
-    await BlockData.updateOne({
-      enable: true,
-    });
-
-    const data = new MessageEmbed({
-      title: "ユーザーブロック",
-      description: "ユーザーをブロックしました",
-      color: 3853014,
-      timestamp: new Date(),
-      thumbnail: {
-        url: profileData.avatar,
-      },
-      fields: [
-        {
-          name: "ユーザーID: ",
-          value: "`" + input + "`",
-          inline: true,
-        },
-        {
-          name: "ユーザー名: ",
-          value: "`" + profileData.name + "`",
-          inline: true,
-        },
-        {
-          name: "Note: ",
-          value:
-            "ブロックを解除する場合は `unblock` コマンドを \n ハードブロックする場合は `hardblock` コマンドを実行してください",
-        },
-      ],
-    });
-    message.channel.send({ embeds: [data] });
-  } catch (err) {
-    logger.error("コマンド実行エラーが発生しました");
-    logger.error(err);
-    message.channel.send({ embeds: [err_embed.main] });
-    if (config.debug.enable.includes("true")) {
-      message.channel.send({ embeds: [err_embed.debug] });
-      message.channel.send("エラー内容: ");
-      message.channel.send("```\n" + err + "\n```");
-    }
-  }
 };
 
 exports.name = "block";

--- a/src/commands/block.js
+++ b/src/commands/block.js
@@ -69,6 +69,31 @@ exports.run = async (client, message, args) => {
             return;
         }
 
+        if (BlockData.enable.includes("true")) {
+            const block_notify = new MessageEmbed({
+                title: "通知: 指定のユーザIDはブロック状態です",
+                color: 4886754,
+                timestamp: new Date(),
+                fields: [
+                    {
+                        name: "ユーザーID: ",
+                        value: "`" + input + "`",
+                        inline: true,
+                    },
+                    {
+                        name: "ユーザー名: ",
+                        value: "`" + profileData.name + "`",
+                        inline: true,
+                    },
+                    {
+                        name: "Note: ",
+                        value: "ブロックを解除する場合は `unblock` コマンドを \n ハードブロックする場合は `hardblock` コマンドを実行してください",
+                    },
+                ],
+            });
+            message.channel.send({ embeds: [block_notify] });
+            return;
+        }
         await BlockData.updateOne({
             enable: true,
         });

--- a/src/commands/block.js
+++ b/src/commands/block.js
@@ -71,7 +71,7 @@ exports.run = async (client, message, args) => {
 
         if (BlockData.enable.includes("true")) {
             const block_notify = new MessageEmbed({
-                title: "通知: 指定のユーザIDはブロック状態です",
+                title: "通知: 指定のユーザはすでにブロックされています",
                 color: 4886754,
                 timestamp: new Date(),
                 fields: [

--- a/src/commands/hardblock.js
+++ b/src/commands/hardblock.js
@@ -74,6 +74,31 @@ exports.run = async (client, message, args) => {
             return;
         }
 
+        if (BlockData.hardblock.includes("true")) {
+            const block_notify = new MessageEmbed({
+                title: "通知: 指定のユーザIDはハードブロック状態です",
+                color: 4886754,
+                timestamp: new Date(),
+                fields: [
+                    {
+                        name: "ユーザーID: ",
+                        value: "`" + input + "`",
+                        inline: true,
+                    },
+                    {
+                        name: "ユーザー名: ",
+                        value: "`" + profileData.name + "`",
+                        inline: true,
+                    },
+                    {
+                        name: "Note: ",
+                        value: "ブロックを解除する場合は `unblock` コマンドを \n ハードブロックする場合は `hardblock` コマンドを実行してください",
+                    },
+                ],
+            });
+            message.channel.send({ embeds: [block_notify] });
+            return;
+        }
         await BlockData.updateOne({
             hardblock: true,
         });

--- a/src/commands/hardblock.js
+++ b/src/commands/hardblock.js
@@ -75,7 +75,7 @@ exports.run = async (client, message, args) => {
         }
 
         if (BlockData.hardblock.includes("true")) {
-            const block_notify = new MessageEmbed({
+            const hardblock_notify = new MessageEmbed({
                 title: "通知: 指定のユーザIDはハードブロック状態です",
                 color: 4886754,
                 timestamp: new Date(),
@@ -96,7 +96,7 @@ exports.run = async (client, message, args) => {
                     },
                 ],
             });
-            message.channel.send({ embeds: [block_notify] });
+            message.channel.send({ embeds: [hardblock_notify] });
             return;
         }
         await BlockData.updateOne({

--- a/src/commands/hardblock.js
+++ b/src/commands/hardblock.js
@@ -7,120 +7,113 @@ const BlockUserModel = require("../utils/Schema/BlockUserSchema");
 const err_embed = require("../utils/error-embed");
 
 exports.run = async (client, message, args) => {
-  try {
-    const permission_check = check_admin(message, client);
+    try {
+        const permission_check = check_admin(message, client);
 
-    if (permission_check == "owner: no") {
-      return;
+        if (permission_check == "owner: no") {
+            return;
+        }
+
+        const args = message.content.split(" ").slice(1);
+        const input = args.join(" ");
+
+        // ユーザーIDが指定されていない場合
+        const err_argument = new MessageEmbed({
+            title: "ハードブロック",
+            description: "コマンド実行エラー: 引数が指定されていません",
+            color: 16601703,
+            fields: [
+                {
+                    name: "コマンド実行に必要な引数",
+                    value: "`hardblock 【ハードブロックするユーザーID】`",
+                },
+                {
+                    name: "実行例: ",
+                    value: "`hardblock 927919368665456710`",
+                },
+            ],
+        });
+
+        if (!input) {
+            message.channel.send({ embeds: [err_argument] });
+            return;
+        }
+
+        const profileData = await profileModel.findOne({ _id: input });
+
+        if (!profileData) {
+            message.channel.send("エラー: ユーザープロファイルが見つかりませんでした");
+            logger.error(
+                "ユーザーID: " +
+                    input +
+                    " のプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
+            );
+            return;
+        }
+
+        // block profileの確認
+        const BlockData = await BlockUserModel.findOne({ _id: input });
+        if (!BlockData) {
+            message.channel.send("エラー: ユーザーブロックプロファイルが見つかりませんでした");
+            logger.error(
+                "ユーザーID: " +
+                    input +
+                    " のブロックプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
+            );
+            return;
+        }
+
+        // ハードブロックの前に通常のブロックがされているか確認
+        if (!BlockData.enable.includes("true")) {
+            message.channel.send("エラー: ハードブロックの前に `block` コマンドを実行してください");
+            return;
+        }
+
+        if (config.bot.owner.includes(input)) {
+            message.channel.send("さすがにbotのownerをブロックすることはできません");
+            return;
+        }
+
+        await BlockData.updateOne({
+            hardblock: true,
+        });
+
+        const data = new MessageEmbed({
+            title: "ハードブロック",
+            description: "ユーザーをハードブロックしました",
+            color: 3853014,
+            timestamp: new Date(),
+            thumbnail: {
+                url: profileData.avatar,
+            },
+            fields: [
+                {
+                    name: "ユーザーID: ",
+                    value: "`" + input + "`",
+                    inline: true,
+                },
+                {
+                    name: "ユーザー名: ",
+                    value: "`" + profileData.name + "`",
+                    inline: true,
+                },
+                {
+                    name: "Note: ",
+                    value: "ブロックを解除する場合は `unblock` コマンドを \n ハードブロックを解除する場合は `unhardblock` コマンドを実行してください",
+                },
+            ],
+        });
+        message.channel.send({ embeds: [data] });
+    } catch (err) {
+        logger.error("コマンド実行エラーが発生しました");
+        logger.error(err);
+        message.channel.send({ embeds: [err_embed.main] });
+        if (config.debug.enable.includes("true")) {
+            message.channel.send({ embeds: [err_embed.debug] });
+            message.channel.send("エラー内容: ");
+            message.channel.send("```\n" + err + "\n```");
+        }
     }
-
-    const args = message.content.split(" ").slice(1);
-    const input = args.join(" ");
-
-    // ユーザーIDが指定されていない場合
-    const err_argument = new MessageEmbed({
-      title: "ハードブロック",
-      description: "コマンド実行エラー: 引数が指定されていません",
-      color: 16601703,
-      fields: [
-        {
-          name: "コマンド実行に必要な引数",
-          value: "`hardblock 【ハードブロックするユーザーID】`",
-        },
-        {
-          name: "実行例: ",
-          value: "`hardblock 927919368665456710`",
-        },
-      ],
-    });
-
-    if (!input) {
-      message.channel.send({ embeds: [err_argument] });
-      return;
-    }
-
-    const profileData = await profileModel.findOne({ _id: input });
-
-    if (!profileData) {
-      message.channel.send(
-        "エラー: ユーザープロファイルが見つかりませんでした"
-      );
-      logger.error(
-        "ユーザーID: " +
-          input +
-          " のプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
-      );
-      return;
-    }
-
-    // block profileの確認
-    const BlockData = await BlockUserModel.findOne({ _id: input });
-    if (!BlockData) {
-      message.channel.send(
-        "エラー: ユーザーブロックプロファイルが見つかりませんでした"
-      );
-      logger.error(
-        "ユーザーID: " +
-          input +
-          " のブロックプロファイルを確認しようとしましたがプロファイルデータがありませんでした..."
-      );
-      return;
-    }
-
-    // ハードブロックの前に通常のブロックがされているか確認
-    if (!BlockData.enable.includes("true")) {
-      message.channel.send(
-        "エラー: ハードブロックの前に `block` コマンドを実行してください"
-      );
-      return;
-    }
-
-    if (config.bot.owner.includes(input)) {
-      message.channel.send("さすがにbotのownerをブロックすることはできません");
-      return;
-    }
-
-    await BlockData.updateOne({
-      hardblock: true,
-    });
-
-    const data = new MessageEmbed({
-      title: "ハードブロック",
-      description: "ユーザーをハードブロックしました",
-      color: 3853014,
-      timestamp: new Date(),
-      thumbnail: {
-        url: profileData.avatar,
-      },
-      fields: [
-        {
-          name: "ユーザーID: ",
-          value: "`" + input + "`",
-          inline: true,
-        },
-        {
-          name: "ユーザー名: ",
-          value: "`" + profileData.name + "`",
-          inline: true,
-        },
-        {
-          name: "Note: ",
-          value:
-            "ブロックを解除する場合は `unblock` コマンドを \n ハードブロックを解除する場合は `unhardblock` コマンドを実行してください",
-        },
-      ],
-    });
-    message.channel.send({ embeds: [data] });
-  } catch (err) {
-    logger.error("コマンド実行エラーが発生しました");
-    logger.error(err);
-    message.channel.send({ embeds: [err_embed.main] });
-    if (config.debug.enable.includes("true")) {
-      message.channel.send({ embeds: [err_embed.debug] });
-      message.channel.send("エラー内容: ");
-      message.channel.send("```\n" + err + "\n```");
-    }
-  }
 };
 
 exports.name = "hardblock";

--- a/src/commands/hardblock.js
+++ b/src/commands/hardblock.js
@@ -76,7 +76,7 @@ exports.run = async (client, message, args) => {
 
         if (BlockData.hardblock.includes("true")) {
             const hardblock_notify = new MessageEmbed({
-                title: "通知: 指定のユーザIDはハードブロック状態です",
+                title: "通知: 指定のユーザはすでにハードブロックされています",
                 color: 4886754,
                 timestamp: new Date(),
                 fields: [


### PR DESCRIPTION
close #104 

`block`コマンド、`hardblock`コマンドは雑にガード節と通知用の埋め込みメッセージを送信するように変更しています。