### PR TITLE
fix: スポイラー・不等号囲いされている時はツイート展開を無効化する

### DIFF
--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -1,8 +1,8 @@
 const { MessageEmbed, MessageAttachment } = require("discord.js");
 
 exports.x_twitter_com = (client, message) => {
-    // X or TwitterのツイートURLがスポイラー(||)・不等号囲い(<>)されている時は埋め込み展開しない
-    const ignoreSymbols = /\|\||</;
+    // X or TwitterのツイートURLがスポイラー(||)・不等号囲い(<>)・インラインコードブロック(``)・引用(>)されている時は埋め込み展開しない
+    const ignoreSymbols = /\|\||<|`|>/;
     if(message.content.match(ignoreSymbols)) return;
 
     const postURL = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;

--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -6,8 +6,8 @@ exports.x_twitter_com = (client, message) => {
     const spoilerTag = /\|\||</;
     if(message.content.match(spoilerTag)) return;
 
-    const regex = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
-    const results = message.content.match(regex);
+    const postURL = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
+    const results = message.content.match(postURL);
 
     if (!results) return;
 

--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -2,8 +2,8 @@ const { MessageEmbed, MessageAttachment } = require("discord.js");
 
 exports.x_twitter_com = (client, message) => {
     // X or TwitterのツイートURLがスポイラー(||)・不等号囲い(<>)されている時は埋め込み展開しない
-    const spoilerTag = /\|\||</;
-    if(message.content.match(spoilerTag)) return;
+    const ignoreSymbols = /\|\||</;
+    if(message.content.match(ignoreSymbols)) return;
 
     const postURL = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
     const results = message.content.match(postURL);

--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -2,7 +2,6 @@ const { MessageEmbed, MessageAttachment } = require("discord.js");
 
 exports.x_twitter_com = (client, message) => {
     // X or TwitterのツイートURLがスポイラー(||)・不等号囲い(<>)されている時は埋め込み展開しない
-    console.log(message);
     const spoilerTag = /\|\||</;
     if(message.content.match(spoilerTag)) return;
 

--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -1,6 +1,11 @@
 const { MessageEmbed, MessageAttachment } = require("discord.js");
 
 exports.x_twitter_com = (client, message) => {
+    // X or TwitterのツイートURLがスポイラー(||)・不等号囲い(<>)されている時は埋め込み展開しない
+    console.log(message);
+    const spoilerTag = /\|\||</;
+    if(message.content.match(spoilerTag)) return;
+
     const regex = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
     const results = message.content.match(regex);
 


### PR DESCRIPTION
close #122 
`|| URL ||`と`<URL>`はURL先のツイートの内容・メディア内容を埋め込み展開しないようにしました。