### PR TITLE
docs:コマンドリファレンスの参照先をGitHub Pagesに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## この Bot のコマンド一覧をみたい場合
 
-[wiki](https://github.com/NamagomiNetwork/Namagomi-bot/wiki) をごらんください。<br>
+[NamagomiNetwork.github.io](https://namagominetwork.github.io/) をごらんください。<br>
 コマンドの一覧,使用方法をまとめています
 
 ## 前提要件


### PR DESCRIPTION
## 主な変更点
- コマンドリファレンスURLをWikiからGitHub Pagesサイト`https://namagominetwork.github.io/`に変更
関連: https://github.com/NamagomiNetwork/Namagomi-bot/issues/115

## 備考
- 現在時点のhttps://namagominetwork.github.io/ は内容が空なんで、適当にHello World!しか書いてない。
![image](https://github.com/NamagomiNetwork/Namagomi-bot/assets/48423435/1f2e7b11-9819-4601-ae2d-b2b2e13cf988)
