### PR TITLE
feat: Twitter埋め込み展開機能でツイートURLだけ貼られた投稿の削除機能

### DIFF
--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -1,12 +1,16 @@
 const { MessageEmbed, MessageAttachment } = require("discord.js");
 
 exports.x_twitter_com = (client, message) => {
-    const regex = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
-    const results = message.content.match(regex);
+    const mentionPostRegex = /[ぁ-んァ-ヶｱ-ﾝﾞﾟ一-龠]*/;
+    const mentionPostResult = message.content.match(mentionPostRegex);
+    console.log(mentionPostResult[0]);
+    if (mentionPostResult[0]) return;
 
-    if (!results) return;
+    const urlRegex = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
+    const urlRegexResults = message.content.match(urlRegex);
+    if (!urlRegexResults) return;
 
-    let replaceURL = results[0].replace(/twitter.com|x.com/, "api.vxtwitter.com");
+    let replaceURL = urlRegexResults[0].replace(/twitter.com|x.com/, "api.vxtwitter.com");
 
     fetch(replaceURL)
         .then((res) => res.json())

--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -55,4 +55,8 @@ exports.x_twitter_com = (client, message) => {
                 }
             }
         });
+    const delayMS = 100;
+    setTimeout(() => {
+        message.delete();
+    }, delayMS);
 };


### PR DESCRIPTION
close #120 

## 主な変更点
- ひらがな・カタカナ・漢字(ポストへの言及内容と想定)を抽出する正規表現の追加
- ツイートURLだけ貼られた場合、(埋め込みメッセージを後に送信するので)ユーザの投稿を削除する処理を追加