### PR TITLE
chore: `no-redeclare`の警告レベルをエラーにするルールを追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
         "prettier"
     ],
     "rules": {
+        "no-redeclare":"error",
         "no-undef":"warn",
         "no-unused-vars":"warn",
         "indent":["warn",4]


### PR DESCRIPTION
close #27 

変数の再宣言をいつでも潰せるようにESLintのルールに`no-redeclare`を追加して警告レベルでerrorを吐かせておくようにしています。