### PR TITLE
fix: Twitter投稿展開機能の修正

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -6,6 +6,7 @@ const { MessageEmbed } = require("discord.js");
 const BlockUserModel = require("../utils/Schema/BlockUserSchema");
 const TawasiModel = require("../utils/Schema/TawasiSchema");
 const OmikujiModel = require("../utils/Schema/OmikujiSchema");
+const PostExpansionSettingsModel = require("../utils/Schema/PostExpansionSettingsSchema");
 const err_embed = require("../utils/error-embed");
 
 exports.run = async (client, message, args) => {
@@ -93,6 +94,16 @@ exports.run = async (client, message, args) => {
             );
             return;
         }
+        const PostExpansionSettingsData = await PostExpansionSettingsModel.findOne({ _id: message.author.id });
+        if (!PostExpansionSettingsData) {
+            message.channel.send({ embeds: [err_embed.main] });
+            logger.error(
+                "ユーザーID: " +
+                    message.author.id +
+                    " のTwitter投稿展開機能を設定しようとしましたがプロファイルデータがありませんでした..."
+            );
+            return;
+        }
         const data = new MessageEmbed({
             title: "ユーザー情報確認",
             description: "DBに保存されているデータを取得しました",
@@ -152,6 +163,20 @@ exports.run = async (client, message, args) => {
                 {
                     name: "ハードブロックの有無",
                     value: "`" + BlockData.hardblock + "`",
+                    inline: true,
+                },
+                {
+                    name: "投稿展開設定情報",
+                    value: "DBに保存されているブロック情報を表示します",
+                },
+                {
+                    name: "Twitterポスト展開設定有無",
+                    value: "`" + PostExpansionSettingsData.x_twitter_show + "`",
+                    inline: true,
+                },
+                {
+                    name: "Discord投稿設定有無(未使用)",
+                    value: "`" + PostExpansionSettingsData.discord_show + "`",
                     inline: true,
                 },
             ],

--- a/src/commands/utils/help-embed.js
+++ b/src/commands/utils/help-embed.js
@@ -2,158 +2,156 @@ const config = require("../../utils/get-config");
 const { MessageEmbed } = require("discord.js");
 
 const top = new MessageEmbed({
-  title: "Page(1/4)",
-  fields: [
-    {
-      name: "基本コマンド",
-      value:
-        "------------------------------ \n このbotの基本的なコマンドを表示します \n コマンドは、設定したprefix + コマンド名 で動作します \n ------------------------------",
-    },
-    {
-      name: "`omikuji`",
-      value: "おみくじをします",
-    },
-    {
-      name: "`vote [タイトル] [投票1] [投票2] ● ● ●`",
-      value: "投票を行います",
-    },
-    {
-      name: "`random [試行回数] [選択肢1] [選択肢2] ● ● ●`",
-      value: "抽選を行います",
-    },
-    {
-      name: "`help-(pageID)`",
-      value: "指定したページID(例: 2)のhelpを表示します",
-    },
-    {
-      name: "次のページを表示する",
-      value: "`help-2`",
-    },
-  ],
+    title: "Page(1/4)",
+    fields: [
+        {
+            name: "基本コマンド",
+            value: "------------------------------ \n このbotの基本的なコマンドを表示します \n コマンドは、設定したprefix + コマンド名 で動作します \n ------------------------------",
+        },
+        {
+            name: "`omikuji`",
+            value: "おみくじをします",
+        },
+        {
+            name: "`vote [タイトル] [投票1] [投票2] ● ● ●`",
+            value: "投票を行います",
+        },
+        {
+            name: "`random [試行回数] [選択肢1] [選択肢2] ● ● ●`",
+            value: "抽選を行います",
+        },
+        {
+            name: "`help-(pageID)`",
+            value: "指定したページID(例: 2)のhelpを表示します",
+        },
+        {
+            name: "次のページを表示する",
+            value: "`help-2`",
+        },
+    ],
 });
 const page2 = new MessageEmbed({
-  title: "Page(2/4)",
-  fields: [
-    {
-      name: "詳細コマンド",
-      value:
-        "------------------------------ \n このbotのシステムに関するコマンドを表示します \n ------------------------------",
-    },
-    {
-      name: "`ping`",
-      value: "ping値を表示します",
-    },
-    {
-      name: "`about`",
-      value: "botの情報を表示します",
-    },
-    {
-      name: "`status`",
-      value: "botのステータスを表示します",
-    },
-    {
-      name: "`version`",
-      value: "botのバージョンを表示します",
-    },
-    {
-      name: "`license`",
-      value: "このbotのライセンスを表示します",
-    },
-    {
-      name: "`user [メンションもしくはID]`",
-      value: "ユーザー情報を表示します",
-    },
-    {
-      name: "次のページを表示する",
-      value: "`help-3`",
-    },
-  ],
+    title: "Page(2/4)",
+    fields: [
+        {
+            name: "詳細コマンド",
+            value: "------------------------------ \n このbotのシステムに関するコマンドを表示します \n ------------------------------",
+        },
+        {
+            name: "`ping`",
+            value: "ping値を表示します",
+        },
+        {
+            name: "`about`",
+            value: "botの情報を表示します",
+        },
+        {
+            name: "`status`",
+            value: "botのステータスを表示します",
+        },
+        {
+            name: "`version`",
+            value: "botのバージョンを表示します",
+        },
+        {
+            name: "`license`",
+            value: "このbotのライセンスを表示します",
+        },
+        {
+            name: "`user [メンションもしくはID]`",
+            value: "ユーザー情報を表示します",
+        },
+        {
+            name: "次のページを表示する",
+            value: "`help-3`",
+        },
+    ],
 });
 const page3 = new MessageEmbed({
-  title: "Page(3/4)",
-  fields: [
-    {
-      name: "設定コマンド",
-      value:
-        "------------------------------ \n このbotの設定機能に関するコマンドを表示します \n ------------------------------",
-    },
-    {
-      name: "`one-day-kuji`",
-      value: "おみくじを1日限定にするかを設定します",
-    },
-    {
-      name: "`one-day-tawasi`",
-      value: "1日1たわしさんを有効にするかを設定します",
-    },
-    {
-      name: "`profile-update`",
-      value: "profileを最新のものに更新します",
-    },
-    {
-      name: "`set-prefix 【設定したいprefix】`",
-      value: "接頭辞を設定します(設定は設定を行ったユーザーのみに)",
-    },
-    {
-      name: "次のページを表示する",
-      value: "`help-4`",
-    },
-  ],
+    title: "Page(3/4)",
+    fields: [
+        {
+            name: "設定コマンド",
+            value: "------------------------------ \n このbotの設定機能に関するコマンドを表示します \n ------------------------------",
+        },
+        {
+            name: "`one-day-kuji`",
+            value: "おみくじを1日限定にするかを設定します",
+        },
+        {
+            name: "`one-day-tawasi`",
+            value: "1日1たわしさんを有効にするかを設定します",
+        },
+        {
+            name: "`profile-update`",
+            value: "profileを最新のものに更新します",
+        },
+        {
+            name: "`set-prefix 【設定したいprefix】`",
+            value: "接頭辞を設定します(設定は設定を行ったユーザーのみに)",
+        },
+        {
+            name: "`set-twitter-url-show 【設定(true|false)】`",
+            value: "Twitter投稿展開機能を設定します(設定は設定を行ったユーザーのみに)",
+        },
+        {
+            name: "次のページを表示する",
+            value: "`help-4`",
+        },
+    ],
 });
 const page4 = new MessageEmbed({
-  title: "Page(4/4)",
-  fields: [
-    {
-      name: "管理者コマンド",
-      value:
-        "------------------------------ \n このコマンドは管理者のみ実行可能です \n ------------------------------",
-    },
-    {
-      name: "`eval 【評価するjsコード】`",
-      value: "コードを評価します",
-    },
-    {
-      name: "`shell 【実行するshellコマンド】`",
-      value: "shellコマンドを実行します",
-    },
-    {
-      name: "`reload 【コマンド名】`",
-      value: "コマンドをリロードします",
-    },
-    {
-      name: "`check 【調べるユーザーのID】`",
-      value: "DBに保存されているデータを表示します",
-    },
-    {
-      name: "`shutdown`",
-      value: "botをシャットダウンします",
-    },
-    {
-      name: "`reset-tawasi 【1日1たわしをリセットするユーザーのID】`",
-      value: "ユーザーの1日1たわしをリセットします",
-    },
-    {
-      name: "`prefix-reset 【リセットするユーザーのID】`",
-      value:
-        "prefixのリセットを行いconfigで設定されているものに強制的に置き換えます",
-    },
-    {
-      name: "`block 【ブロックするユーザーのID】`",
-      value: "ブロックを行い、指定したユーザーのコマンド実行を禁止します",
-    },
-    {
-      name: "`unblock 【ブロックを解除するユーザーのID】`",
-      value: "ユーザーのブロックを解除します",
-    },
-    {
-      name: "`hardblock 【ハードブロックするユーザーのID】`",
-      value:
-        "前提: ユーザーのブロック \n ハードブロックを行った場合ブロックされていることを通知するメッセージを表示しません",
-    },
-    {
-      name: "`unhardblock 【ハードブロックを解除するユーザーのID】`",
-      value: "ユーザーのハードブロックを解除します",
-    },
-  ],
+    title: "Page(4/4)",
+    fields: [
+        {
+            name: "管理者コマンド",
+            value: "------------------------------ \n このコマンドは管理者のみ実行可能です \n ------------------------------",
+        },
+        {
+            name: "`eval 【評価するjsコード】`",
+            value: "コードを評価します",
+        },
+        {
+            name: "`shell 【実行するshellコマンド】`",
+            value: "shellコマンドを実行します",
+        },
+        {
+            name: "`reload 【コマンド名】`",
+            value: "コマンドをリロードします",
+        },
+        {
+            name: "`check 【調べるユーザーのID】`",
+            value: "DBに保存されているデータを表示します",
+        },
+        {
+            name: "`shutdown`",
+            value: "botをシャットダウンします",
+        },
+        {
+            name: "`reset-tawasi 【1日1たわしをリセットするユーザーのID】`",
+            value: "ユーザーの1日1たわしをリセットします",
+        },
+        {
+            name: "`prefix-reset 【リセットするユーザーのID】`",
+            value: "prefixのリセットを行いconfigで設定されているものに強制的に置き換えます",
+        },
+        {
+            name: "`block 【ブロックするユーザーのID】`",
+            value: "ブロックを行い、指定したユーザーのコマンド実行を禁止します",
+        },
+        {
+            name: "`unblock 【ブロックを解除するユーザーのID】`",
+            value: "ユーザーのブロックを解除します",
+        },
+        {
+            name: "`hardblock 【ハードブロックするユーザーのID】`",
+            value: "前提: ユーザーのブロック \n ハードブロックを行った場合ブロックされていることを通知するメッセージを表示しません",
+        },
+        {
+            name: "`unhardblock 【ハードブロックを解除するユーザーのID】`",
+            value: "ユーザーのハードブロックを解除します",
+        },
+    ],
 });
 exports.top = top;
 exports.page2 = page2;

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -47,9 +47,7 @@ module.exports = async (client, message) => {
     // URL展開
     url.discord_com(client, message);
     url.discord_ptb_com(client, message);
-    if (postExpansionSettingsData.x_twitter_show.includes("true")) {
-        twitter_url.x_twitter_com(client, message);
-    }
+    twitter_url.x_twitter_com(client, message);
 
     // とあるメッセージに対して画像を送ったりする
     msg_reply(message);

--- a/src/sub-systems/twitter-url-show.js
+++ b/src/sub-systems/twitter-url-show.js
@@ -1,9 +1,24 @@
 const { MessageEmbed, MessageAttachment } = require("discord.js");
+const err_embed = require("../utils/error-embed");
+const postExpansionSettingsModel = require("../utils/Schema/PostExpansionSettingsSchema");
 
-exports.x_twitter_com = (client, message) => {
+exports.x_twitter_com = async (client, message) => {
+    const postExpansionSettingsData = await postExpansionSettingsModel.findOne({ _id: message.author.id });
+    if (!postExpansionSettingsData) {
+        message.channel.send({ embeds: [err_embed.main] });
+        logger.error(
+            "ユーザーID: " +
+                message.author.id +
+                " のTwitter投稿展開機能を設定しようとしましたがプロファイルデータがありませんでした..."
+        );
+        return;
+    }
+
+    if (postExpansionSettingsData.x_twitter_show.includes("false")) return;
+
     // X or TwitterのツイートURLがスポイラー(||)・不等号囲い(<>)・インラインコードブロック(``)・引用(>)されている時は埋め込み展開しない
     const ignoreSymbols = /\|\||<|`|>/;
-    if(message.content.match(ignoreSymbols)) return;
+    if (message.content.match(ignoreSymbols)) return;
 
     const postURL = /https:\/\/(twitter\.com|x\.com)\/[A-Za-z0-9_]*\/status\/(\d+)/;
     const results = message.content.match(postURL);


### PR DESCRIPTION
fix #125 

## 主な変更点
- Twitter投稿展開機能を投稿内容展開機能向け設定スキーマ.x_twitter_showの設定に基づく条件分岐を`twitter-url-show`内で実施するように変更。（true時は展開される。false時は展開しない。については変更なし）
- ついでに`check`コマンドで表示するユーザ情報に投稿内容展開情報を追加

## 備考
`check`コマンドで追加した項目の表示イメージ（最下部）
![image](https://github.com/NamagomiNetwork/Namagomi-bot/assets/48423435/8c2c170a-546c-455e-89e7-906c51e03807)
