### PR TITLE
feat: コマンド推測機能を追加

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -49,7 +49,6 @@ module.exports = async (client, message) => {
     url.discord_ptb_com(client, message);
     twitter_url.x_twitter_com(client, message);
 
-
     // とあるメッセージに対して画像を送ったりする
     msg_reply(message);
 
@@ -213,16 +212,36 @@ module.exports = async (client, message) => {
         message.channel.send({ embeds: [your_block] });
         return;
     }
+
+    const cmd = client.commands.get(command);
+    let indicateDisplay = () => {
+        console.log(command);
+        const input = command.toLowerCase();
+        for (const [key, value] of client.commands) {
+            if (key.toLowerCase().startsWith(input)) {
+                return key;
+            }
+        }
+
+        return null;
+    };
+    const indicateCmdName = indicateDisplay(cmd);
     const unknown_command = new MessageEmbed({
         title: "コマンドが不明です😉",
         color: 16601703,
+        fields: [
+            {
+                name: "もしかして：",
+                value: "`" + indicateCmdName + "`",
+            },
+        ],
         footer: {
             text: "??? 「そんなコマンドないで」",
         },
         description: "コマンドが存在しません。helpを確認してください",
     });
-    const cmd = client.commands.get(command);
     if (!cmd) {
+        console.log(indicateCmdName);
         message.channel.send({ embeds: [unknown_command] });
         return;
     }

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -216,7 +216,7 @@ module.exports = async (client, message) => {
     const cmd = client.commands.get(command);
     let indicateDisplay = () => {
         const input = command.toLowerCase();
-        for (const [key, value] of client.commands) {
+        for (const [key] of client.commands) {
             if (key.toLowerCase().startsWith(input)) {
                 return key;
             }

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -215,7 +215,6 @@ module.exports = async (client, message) => {
 
     const cmd = client.commands.get(command);
     let indicateDisplay = () => {
-        console.log(command);
         const input = command.toLowerCase();
         for (const [key, value] of client.commands) {
             if (key.toLowerCase().startsWith(input)) {
@@ -241,7 +240,6 @@ module.exports = async (client, message) => {
         description: "コマンドが存在しません。helpを確認してください",
     });
     if (!cmd) {
-        console.log(indicateCmdName);
         message.channel.send({ embeds: [unknown_command] });
         return;
     }


### PR DESCRIPTION
close #143 

## 主な変更点
コマンドを打ち間違えて送信してしまったときの`unknown_command`にコマンド推測機能を追加

## 表示サンプル
入力例
`g!omi`

![image](https://github.com/NamagomiNetwork/Namagomi-bot/assets/48423435/4b8961e0-9cd1-4c47-9416-d6fd0ba93673)

